### PR TITLE
Allow ampersands (&) in activity titles

### DIFF
--- a/lib/neoboard/widgets/redmine_activity.ex
+++ b/lib/neoboard/widgets/redmine_activity.ex
@@ -143,7 +143,7 @@ defmodule Neoboard.Widgets.RedmineActivity.Parser do
   end
 
   defp extract_project_name(entry) do
-    entry |> Xml.first('./title') |> Xml.text |> match(~r/^([\w\-_ ]+) - /)
+    entry |> Xml.first('./title') |> Xml.text |> match(~r/^([&\w\-_ ]+) - /)
   end
 
   defp extract_updated(entry) do
@@ -176,7 +176,9 @@ defmodule Neoboard.Widgets.RedmineActivity.Xml do
 
   def text(node), do: node |> xpath('./text()') |> extract_text
   defp extract_text([xmlText(value: value)]), do: List.to_string(value)
-  defp extract_text([xmlText(value: value) | _x]), do: List.to_string(value)
+  defp extract_text([xmlText(value: value) | rest]) do
+    List.to_string(value) <> extract_text(rest)
+  end
   defp extract_text(xmlText(value: value)), do: List.to_string(value)
   defp extract_text([]), do: ""
 end

--- a/test/neoboard/widgets/redmine_activity_fixture.xml
+++ b/test/neoboard/widgets/redmine_activity_fixture.xml
@@ -52,7 +52,7 @@ Redmine  </generator>
     </content>
   </entry>
   <entry>
-    <title>project3 - Revision 706ee6fd (project3): Merge branch 'feature-xyz'</title>
+    <title>project3 &amp; more - Revision 706ee6fd (project3): Merge branch 'feature-xyz'</title>
     <link rel="alternate" href="https://redmine.company.com/projects/project3/repository/revisions/706ee6fd874515cb6de082d1a9a22dda1709a249"/>
     <id>https://redmine.company.com/projects/project3/repository/revisions/706ee6fd874515cb6de082d1a9a22dda1709a249</id>
     <updated>2015-05-18T15:02:59Z</updated>

--- a/test/neoboard/widgets/redmine_activity_test.exs
+++ b/test/neoboard/widgets/redmine_activity_test.exs
@@ -19,7 +19,7 @@ defmodule Neoboard.Widgets.RedmineActivityTest do
     assert Enum.empty?(rest)
 
     [second | one_project] = two_projects
-    assert second.name       == "project3"
+    assert second.name       == "project3 & more"
     assert second.activity   == 1
     assert second.updated_at == Timex.datetime({{2015,5,18},{15,02,59}})
     [user | rest] = second.users
@@ -50,5 +50,15 @@ defmodule Neoboard.Widgets.RedmineActivityTest do
   defp load_fixture! do
     Path.join(__DIR__, "redmine_activity_fixture.xml")
     |> File.read!
+  end
+end
+
+defmodule Neoboard.Widgets.RedmineActivity.XmlTest do
+  use ExUnit.Case, async: true
+  alias Neoboard.Widgets.RedmineActivity.Xml
+
+  test "handles text nodes with ampersand" do
+    source = Xml.load_xml("<title>code &amp; fun</title>")
+    assert Xml.text(source) == "code & fun"
   end
 end


### PR DESCRIPTION
Before this commit titles like "Marketing & Sales" broke
the parse with the following error message:

```
09:22:17.370 [info] [ProcessCushion] Starting Elixir.Neoboard.Widgets.RedmineActivity with delay of 10000
09:22:17.372 [error] GenServer #PID<0.757.0> terminating
** (FunctionClauseError) no function clause matching in List.first/1
    (elixir) lib/list.ex:163: List.first(nil)
    (neoboard) lib/neoboard/widgets/redmine_activity.ex:135: Neoboard.Widgets.RedmineActivity.Parser.extract_project/1
    (neoboard) lib/neoboard/widgets/redmine_activity.ex:125: Neoboard.Widgets.RedmineActivity.Parser.reduce_project/2
    (elixir) lib/enum.ex:1473: Enum."-reduce/3-lists^foldl/2-0-"/3
    (neoboard) lib/neoboard/widgets/redmine_activity.ex:95: Neoboard.Widgets.RedmineActivity.Parser.parse!/1
    (neoboard) lib/neoboard/widgets/redmine_activity.ex:24: Neoboard.Widgets.RedmineActivity.fetch/0
    (neoboard) lib/neoboard/widgets/redmine_activity.ex:16: Neoboard.Widgets.RedmineActivity.handle_info/2
    (stdlib) gen_server.erl:615: :gen_server.try_dispatch/4
```

This commit fixes that issue.

@jnbt BTW, as a workaround I've renamed the project to "Marketing & Sales". So, don't hurry ;)
