### PR TITLE
Implement a widget for Mattermost chat

### DIFF
--- a/config/widgets.exs
+++ b/config/widgets.exs
@@ -39,6 +39,15 @@ config :neoboard, Neoboard.Widgets.Time,
 #   every: 10_000,
 #   title: "gitter.im/yourRoom"
 
+#config :neoboard, Neoboard.Widgets.Mattermost,
+#  api_url: "http://mattermost.company.com/api/v3",
+#  private_token: "verysecret",
+#  team_id: "your_team_id",
+#  channel_id: "the_channel_id",
+#  every: 10_000,
+#  posts: 10,
+#  title: "mattermost/town-square"
+
 # config :neoboard, Neoboard.Widgets.OwncloudImages,
 #   url: "https://owncloud.company.com/public.php?service=files&t=SECRET_TOKEN",
 #   every: 10_000

--- a/lib/neoboard/gravatar.ex
+++ b/lib/neoboard/gravatar.ex
@@ -1,0 +1,23 @@
+defmodule Neoboard.Gravatar do
+  def url(email) do
+    %URI{scheme: "https", host: "secure.gravatar.com/avatar/"}
+    |> add_email(email)
+    |> to_string
+  end
+
+  defp add_email(uri, email) do
+    %URI{uri | path: hash_email(email)}
+  end
+
+  defp hash_email(email) do
+    email
+    |> String.trim
+    |> String.downcase
+    |> md5
+    |> Base.encode16(case: :lower)
+  end
+
+  defp md5(string) do
+    :crypto.hash(:md5, string)
+  end
+end

--- a/lib/neoboard/widgets/mattermost.ex
+++ b/lib/neoboard/widgets/mattermost.ex
@@ -1,0 +1,44 @@
+defmodule Neoboard.Widgets.Mattermost do
+  use GenServer
+  use Neoboard.Pusher
+  use Neoboard.Config
+  alias Neoboard.TimeService
+  alias Neoboard.Widgets.Mattermost.Fetcher
+
+  def start_link do
+    {:ok, pid} = GenServer.start_link(__MODULE__, :ok)
+    send(pid, :tick)
+    :timer.send_interval(config[:every], pid, :tick)
+    {:ok, pid}
+  end
+
+  def init(:ok) do
+    HTTPoison.start
+
+    {:ok, %{
+      posts: [],
+      last_fetch: initial_last_fetch
+    }}
+  end
+
+  def handle_info(:tick, state) do
+    {:ok, new_posts} = Fetcher.fetch(state[:last_fetch], config)
+    posts = new_posts ++ state[:posts] |> Enum.take(config[:posts])
+
+    push_posts! posts
+
+    {:noreply, %{
+      posts: posts,
+      last_fetch: TimeService.now
+    }}
+  end
+
+  defp initial_last_fetch do
+    offset = Dict.get(config, :offset, days: -7)
+    Timex.shift(TimeService.now, offset)
+  end
+
+  defp push_posts!(posts) do
+    push! %{posts: posts, title: config[:title]}
+  end
+end

--- a/lib/neoboard/widgets/mattermost/fetcher.ex
+++ b/lib/neoboard/widgets/mattermost/fetcher.ex
@@ -1,0 +1,102 @@
+defmodule Neoboard.Widgets.Mattermost.Fetcher do
+  alias Neoboard.Widgets.Mattermost.Fetcher
+  alias Neoboard.Gravatar
+  alias Timex.DateTime
+
+  defstruct [:api_url, :private_token, :channel_id, :team_id, :since, :posts, :users]
+
+  def fetch(since, config) do
+    %Fetcher{
+      api_url: config[:api_url],
+      private_token: config[:private_token],
+      team_id: config[:team_id],
+      channel_id: config[:channel_id],
+      since: since,
+      posts: [],
+      users: %{}
+    } |> fetch
+  end
+
+  defp fetch(fetcher) do
+    fetcher = fetcher
+    |> fetch_posts
+    |> fetch_users
+    |> inject_users
+
+    {:ok, fetcher.posts}
+  end
+
+  defp fetch_posts(fetcher) do
+    posts = fetcher
+    |> request(posts_url(fetcher))
+    |> Dict.get("posts")
+    |> extract_posts
+
+    %{fetcher | posts: posts}
+  end
+
+  defp fetch_users(fetcher) do
+    users = fetcher
+    |> request(users_url(fetcher))
+    |> extract_users
+
+    %{fetcher | users: users}
+  end
+
+  defp inject_users(fetcher) do
+    posts = Enum.map(fetcher.posts, fn(post) ->
+      Dict.put(post, "user", Dict.get(fetcher.users, post["user_id"]))
+    end)
+
+    %{fetcher | posts: posts}
+  end
+
+  defp extract_posts(nil), do: []
+  defp extract_posts(posts) do
+    posts
+    |> Dict.values
+    |> Enum.filter(&(&1["delete_at"] == 0))
+    |> Enum.sort(&(&1["create_at"] > &2["create_at"]))
+  end
+
+  defp extract_users(nil), do: %{}
+  defp extract_users(users) do
+    Enum.reduce(users, %{}, fn({id, user}, acc) ->
+      Dict.put(acc, id, Dict.put(user, "avatar_url", avatar_url(user)))
+    end)
+  end
+
+  defp request(fetcher, url) do
+    result = HTTPoison.get(url, headers(fetcher))
+    {:ok, %HTTPoison.Response{status_code: 200, body: body}} = result
+    body |> Poison.decode!
+  end
+
+  defp headers(%Fetcher{private_token: token}) do
+    %{
+      "Authorization" => "Bearer #{token}",
+      "Accept" => "application/json"
+    }
+  end
+
+  defp posts_url(fetcher = %Fetcher{team_id: team, channel_id: channel, since: since}) do
+    timestamp = to_timestamp(since)
+    fetcher |> url("teams/#{team}/channels/#{channel}/posts/since/#{timestamp}")
+  end
+
+  defp users_url(fetcher = %Fetcher{team_id: team_id}) do
+    fetcher |> url("users/profiles/#{team_id}")
+  end
+
+  defp avatar_url(user) do
+    Gravatar.url(user["email"])
+  end
+
+  defp url(%Fetcher{api_url: url}, path) do
+    "#{url}/#{path}"
+  end
+
+  defp to_timestamp(since) do
+    DateTime.to_seconds(since) * 1000
+  end
+end

--- a/test/neoboard/gravatar_test.exs
+++ b/test/neoboard/gravatar_test.exs
@@ -1,0 +1,9 @@
+defmodule Neoboard.GravatarTest do
+  use ExUnit.Case, async: true
+  alias Neoboard.Gravatar
+
+  test "it builds the url with hashed email" do
+    url = Gravatar.url("MyEmailAddress@example.com")
+    assert url == "https://secure.gravatar.com/avatar/0bc83cb571cd1c50ba6f3e8a78ef1346"
+  end
+end

--- a/test/neoboard/widgets/mattermost_fetcher_test.exs
+++ b/test/neoboard/widgets/mattermost_fetcher_test.exs
@@ -1,0 +1,144 @@
+defmodule Neoboard.Widgets.MattermostFetcherTest do
+  use ExUnit.Case, async: true
+  alias Neoboard.Widgets.Mattermost.Fetcher
+  alias Timex.DateTime
+
+  setup do
+    bypass = Bypass.open
+    {:ok, bypass: bypass}
+  end
+
+  @config %{
+    private_token: "the_private_token",
+    team_id: "the_team_id",
+    channel_id: "the_channel_id"
+  }
+
+  test "w/o posts and users returns no posts", %{bypass: bypass} do
+    since = DateTime.epoch
+    config = build_config(bypass)
+
+    posts = "/teams/the_team_id/channels/the_channel_id/posts/since/0"
+    Bypass.expect bypass, "GET", posts, fn conn ->
+      conn = Plug.Conn.fetch_query_params(conn)
+      assert_request_header(conn, "authorization", "Bearer the_private_token")
+      send_json(conn, %{})
+    end
+
+    users = "/users/profiles/the_team_id"
+    Bypass.expect bypass, "GET", users, fn conn ->
+      conn = Plug.Conn.fetch_query_params(conn)
+      assert_request_header(conn, "authorization", "Bearer the_private_token")
+      send_json(conn, %{})
+    end
+
+    assert {:ok, []} = Fetcher.fetch(since, config)
+  end
+
+  test "ignores deleted posts", %{bypass: bypass} do
+    since = DateTime.epoch
+    config = build_config(bypass)
+    posts = "/teams/the_team_id/channels/the_channel_id/posts/since/0"
+    Bypass.expect bypass, "GET", posts, fn conn ->
+      conn = Plug.Conn.fetch_query_params(conn)
+      assert_request_header(conn, "authorization", "Bearer the_private_token")
+      send_json(conn, %{
+        "order" => ["p1"],
+        "posts" => %{
+          "p1" => %{
+            "id"        => "p1",
+            "message"   => "Some message",
+            "user_id"   => "u1",
+            "delete_at" => 1476880485,
+            "create_at" => 1476880484
+          }
+        }
+      })
+    end
+
+    users = "/users/profiles/the_team_id"
+    Bypass.expect bypass, "GET", users, fn conn ->
+      conn = Plug.Conn.fetch_query_params(conn)
+      assert_request_header(conn, "authorization", "Bearer the_private_token")
+      send_json(conn, %{
+        "u1" => %{
+          "username" => "the_username",
+          "email" => "MyEmailAddress@example.com"
+        }
+      })
+    end
+
+    assert {:ok, []} = Fetcher.fetch(since, config)
+  end
+
+  test "injects enriched users into posts", %{bypass: bypass} do
+    since = DateTime.epoch
+    config = build_config(bypass)
+
+    posts = "/teams/the_team_id/channels/the_channel_id/posts/since/0"
+    Bypass.expect bypass, "GET", posts, fn conn ->
+      conn = Plug.Conn.fetch_query_params(conn)
+      assert_request_header(conn, "authorization", "Bearer the_private_token")
+      send_json(conn, %{
+        "order" => ["p1"],
+        "posts" => %{
+          "p1" => %{
+            "id"        => "p1",
+            "message"   => "Some message",
+            "user_id"   => "u1",
+            "delete_at" => 0,
+            "create_at" => 1476880484
+          }
+        }
+      })
+    end
+
+    users = "/users/profiles/the_team_id"
+    Bypass.expect bypass, "GET", users, fn conn ->
+      conn = Plug.Conn.fetch_query_params(conn)
+      assert_request_header(conn, "authorization", "Bearer the_private_token")
+      send_json(conn, %{
+        "u1" => %{
+          "username" => "the_username",
+          "email" => "MyEmailAddress@example.com"
+        }
+      })
+    end
+
+    expected = [%{
+      "create_at" => 1476880484,
+      "delete_at" => 0,
+      "id"        => "p1",
+      "message"   => "Some message",
+      "user_id"   => "u1",
+      "user"    => %{
+        "avatar_url" => "https://secure.gravatar.com/avatar/0bc83cb571cd1c50ba6f3e8a78ef1346",
+        "email" => "MyEmailAddress@example.com",
+        "username" => "the_username"
+      }
+    }]
+
+    assert {:ok, ^expected} = Fetcher.fetch(since, config)
+  end
+
+  defp build_config(bypass) do
+    Dict.merge(@config, %{
+      api_url: endpoint_url(bypass)
+    })
+  end
+
+  def assert_request_header(conn, key, value) do
+    val = conn.req_headers
+    |> Enum.find_value(fn {k, v} -> k == key && v end)
+    assert val == value
+  end
+
+  defp send_json(conn, value) do
+    json = Poison.encode!(value)
+    Plug.Conn.resp(conn, 200, json)
+  end
+
+  defp endpoint_url(bypass) do
+    "http://localhost:#{bypass.port}"
+  end
+end

--- a/web/static/css/main.sass
+++ b/web/static/css/main.sass
@@ -30,3 +30,4 @@ body
 @import "widgets/redmine_activity_users"
 @import "widgets/owncloud_images"
 @import "widgets/images"
+@import "widgets/mattermost"

--- a/web/static/css/widgets/_mattermost.sass
+++ b/web/static/css/widgets/_mattermost.sass
@@ -1,0 +1,70 @@
+.MattermostWidget
+  +widget
+  background: #2D8F88
+  justify-content: flex-start
+
+  > h2
+    +font-medium
+    color: $halfWhite
+
+  .scrollable
+    position: absolute
+    left: 10px
+    top: 80px
+    right: 10px
+    bottom: 40px
+    overflow: hidden
+
+    .scrollable-content
+      position: absolute
+      left: 0
+      right: 0
+      bottom: 0
+
+  ol
+    list-style: none
+    margin: 0
+    padding: 0
+    text-align: left
+
+    > li
+      margin-top: 5px
+
+    .avatar
+      float: left
+      width: 10%
+      height: 10%
+      margin-right: 3%
+
+      img
+        width: 100%
+        height: 100%
+
+    .content
+      float: left
+      width: 86%
+      .meta
+        color: $thirdWhite
+        font-size: 0.7rem
+        .displayName
+          margin-right: 7px
+
+      p
+        display: -webkit-box
+        color: $twoThirdWhite
+        font-size: 0.9rem
+        max-height: 75px
+        margin: 0
+        -webkit-line-clamp: 4
+        -webkit-box-orient: vertical
+        overflow: hidden
+        text-overflow: ellipsis
+        img.emoji
+          width: 1.5em
+          height: 1.5em
+          display: inline-block
+          margin-bottom: 0.25em
+          background-size: contain
+
+    .clear
+      clear: both

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -8,6 +8,7 @@ import NotepadWidget from "./widgets/notepad"
 import NichtLustigWidget from "./widgets/nicht_lustig"
 import RedmineProjectTable from "./widgets/redmine_project_table"
 import Gitter from "./widgets/gitter"
+import Mattermost from "./widgets/mattermost"
 import RedmineActivityProjects from "./widgets/redmine_activity_projects"
 import RedmineActivityUsers from "./widgets/redmine_activity_users"
 import OwncloudImages from "./widgets/owncloud_images"
@@ -16,7 +17,7 @@ import Images from "./widgets/images"
 const widgets = [
   // Format:
   // [widget, grid configuration]
-  [Gitter,                  {x:0, y:0, w:1, h:2}],
+  [Mattermost,              {x:0, y:0, w:1, h:2}],
   [RedmineActivityProjects, {x:1, y:0, w:1, h:2}],
   [RedmineActivityUsers,    {x:2, y:0, w:1, h:1}],
   [OwncloudImages,          {x:4, y:1, w:1, h:1}],

--- a/web/static/js/widgets/mattermost.js
+++ b/web/static/js/widgets/mattermost.js
@@ -1,0 +1,89 @@
+import React from "react"
+import WidgetMixin from "../widget_mixin"
+import LastUpdatedAt from "../last_updated_at"
+import Emojify from "emojify"
+import {FormattedRelative} from "react-intl"
+import ReactCSSTransitionGroup from "react-addons-css-transition-group"
+
+const Post = React.createClass({
+  getDefaultProps() {
+    return { interval: 1000 * 60 } // 1 minute
+  },
+  render() {
+    return (
+      <div>
+        <div className="avatar">
+          <img src={this.props.user.avatar_url}/>
+        </div>
+        <div className="content">
+          <div className="meta">
+            <span className="displayName">
+              {this.props.user.first_name} {this.props.user.last_name}
+            </span>
+            <FormattedRelative value={this.props.create_at}/>
+          </div>
+          <p ref={(p) => this._body = p}>{this.props.message}</p>
+        </div>
+        <div className="clear"/>
+      </div>
+    )
+  },
+  componentDidMount() {
+    Emojify.run(this._body)
+    this._update()
+  },
+  componentWillUnmount() {
+    this._clearTimeout()
+  },
+  _update() {
+    this._clearTimeout()
+    this.timeout = setTimeout(this._update, this.props.interval)
+    this.forceUpdate()
+  },
+  _clearTimeout() {
+    if(this.timeout) {
+      clearTimeout(this.timeout)
+      delete this.timeout
+    }
+  }
+})
+
+export default React.createClass({
+  mixins: [WidgetMixin("mattermost:state")],
+  getDefaultProps() {
+    return {transition: "transitionFade"}
+  },
+  getInitialState() {
+    return {
+      title: "",
+      posts: []
+    }
+  },
+  render() {
+    return (
+      <div className="MattermostWidget">
+        <h2>{this.state.title}</h2>
+        <div className="scrollable">
+          <div className="scrollable-content">
+            <ReactCSSTransitionGroup
+              transitionName={this.props.transition}
+              transitionEnterTimeout={500}
+              transitionLeaveTimeout={500}
+              component="ol">
+              {this.state.posts.reverse().map(this._renderPost)}
+            </ReactCSSTransitionGroup>
+          </div>
+        </div>
+        <img src={this.state.url} />
+        <LastUpdatedAt updated_at={this.state.updated_at}/>
+      </div>
+    )
+  },
+  _renderPost(post) {
+    return (
+      <li key={post.id}>
+        <Post {...post}/>
+      </li>
+    )
+  }
+})


### PR DESCRIPTION
- First iteration will use a polling based approach.
  - Websockets are available in Mattermost, but this needs a new libs to handle the connection
- It simply uses an extracted access token for authentication
- As the internal Mattermost avatars are not loadable w/o the access token, and I don't want it to be exposed to the client, the widget uses Gravatar for the avatar images.

/cc @splattael 
