### PR TITLE
Use ReactMarkdown to render messages in Mattermost

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "repository": {},
   "dependencies": {
     "classnames": "~2.2.5",
+    "json-loader": "^0.5.4",
     "lodash": "~4.16.2",
     "react": "~15.3.2",
     "react-addons-css-transition-group": "~15.3.2",
     "react-dom": "~15.3.2",
     "react-grid-layout": "~0.13.6",
-    "react-intl": "~2.1.5"
+    "react-intl": "~2.1.5",
+    "react-markdown": "^2.4.2"
   },
   "devDependencies": {
     "webpack": "~1.13.2",

--- a/web/static/css/widgets/_mattermost.sass
+++ b/web/static/css/widgets/_mattermost.sass
@@ -49,16 +49,28 @@
         .displayName
           margin-right: 7px
 
-      p
+      .body
         display: -webkit-box
         color: $twoThirdWhite
         font-size: 0.9rem
-        max-height: 75px
         margin: 0
-        -webkit-line-clamp: 4
-        -webkit-box-orient: vertical
-        overflow: hidden
-        text-overflow: ellipsis
+        word-wrap: break-word
+
+        > div
+          width: 100%
+
+        a:link, a:visited, a:active
+          color: $twoThirdWhite
+        a:hover
+          color: $white
+        p
+          margin: 0
+
+        blockquote
+          margin: 5px 0 5px 0
+          padding-left: 5px
+          border-left: 3px solid $thirdWhite
+
         img.emoji
           width: 1.5em
           height: 1.5em

--- a/web/static/js/widgets/mattermost.js
+++ b/web/static/js/widgets/mattermost.js
@@ -4,6 +4,7 @@ import LastUpdatedAt from "../last_updated_at"
 import Emojify from "emojify"
 import {FormattedRelative} from "react-intl"
 import ReactCSSTransitionGroup from "react-addons-css-transition-group"
+import ReactMarkdown from "react-markdown"
 
 const Post = React.createClass({
   getDefaultProps() {
@@ -22,7 +23,9 @@ const Post = React.createClass({
             </span>
             <FormattedRelative value={this.props.create_at}/>
           </div>
-          <p ref={(p) => this._body = p}>{this.props.message}</p>
+          <div ref={(p) => this._body = p} className="body">
+            <ReactMarkdown source={this.props.message} />
+          </div>
         </div>
         <div className="clear"/>
       </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,10 @@ module.exports = {
       test: /\.js$/,
       exclude: /node_modules/,
       loader: "babel-loader"
+    },
+    {
+      test: /\.json$/,
+      loader: "json"
     }
     ]
   }


### PR DESCRIPTION
As Mattermost is using Markdown for the messages we can use ReactMarkdown to render the messages.