### PR TITLE
Implement GitLab API V4 

### DIFF
--- a/web/static/css/widgets/_gitlab_ci.sass
+++ b/web/static/css/widgets/_gitlab_ci.sass
@@ -21,9 +21,8 @@
 
   ul
     +inline-list
-    max-height: 70px
+    height: 70px
     overflow: hidden
-    margin: 25px 0 35px 0
     padding: 0 10px
     li, a
       color: $halfWhite

--- a/web/static/css/widgets/_gitlab_ci.sass
+++ b/web/static/css/widgets/_gitlab_ci.sass
@@ -7,6 +7,8 @@
     background: #4ad55e
   &.sad
     background: #cd181b
+  &.unknown
+    background: #666666
 
   h2
     +font-xlarge

--- a/web/static/js/widgets/gitlab_ci.js
+++ b/web/static/js/widgets/gitlab_ci.js
@@ -3,7 +3,7 @@ import WidgetMixin from "../widget_mixin"
 import LastUpdatedAt from "../last_updated_at"
 import classNames from "classnames"
 
-const MAX_NUMBER_OF_JOBS = 10
+const MAX_NUMBER_OF_JOBS = 4
 
 export default React.createClass({
   mixins: [WidgetMixin("gitlab_ci:state")],

--- a/web/static/js/widgets/gitlab_ci.js
+++ b/web/static/js/widgets/gitlab_ci.js
@@ -5,21 +5,23 @@ import classNames from "classnames"
 
 const MAX_NUMBER_OF_JOBS = 4
 
+const BUILD_STATE = {
+  happy: "happy",
+  sad: "sad",
+  unknown: "unknown"
+}
+
 export default React.createClass({
   mixins: [WidgetMixin("gitlab_ci:state")],
   getInitialState() {
     return {
-      happy: true,
+      build: BUILD_STATE.unknown,
       failed_jobs: []
     }
   },
   render() {
-    let cls = classNames("GitlabCiWidget", {
-      happy: this.state.happy,
-      sad: !this.state.happy
-    })
     return (
-      <div className={cls}>
+      <div className={classNames("GitlabCiWidget", this.state.build)}>
         <h2>CI</h2>
         {this._renderStatus()}
         <ul>
@@ -31,13 +33,18 @@ export default React.createClass({
   },
   transform(storeState){
     return {
-      happy: storeState.failed_jobs.length === 0,
+      build: storeState.failed_jobs.length === 0 ? BUILD_STATE.happy : BUILD_STATE.sad,
       failed_jobs: storeState.failed_jobs
     }
   },
   _renderStatus() {
-    if(this.state.happy) return <div className="status happy">✔</div>
-    else return <div className="status sad">☹</div>
+    return (
+      <div className={classNames("status", this.state.build)}>
+        {this.state.build === BUILD_STATE.happy && "✔"}
+        {this.state.build === BUILD_STATE.sad && "☹"}
+        {this.state.build === BUILD_STATE.unknown && "?"}
+      </div>
+    )
   },
   _renderJobs(){
     let jobs = this.state.failed_jobs.splice(0, MAX_NUMBER_OF_JOBS-1).map(this._renderJob)


### PR DESCRIPTION
* Upgrade new API v4 (/projects, /pipelines)
* Respect only the default branch for build status
* Ignore archived projects
* Visualize unknown build status to reduce confusions in the future

Refs #18 

/cc @wakkowarner @shlub 