### PR TITLE
Fix to restrictive Redmine project name extraction

### DIFF
--- a/lib/neoboard/widgets/redmine_activity.ex
+++ b/lib/neoboard/widgets/redmine_activity.ex
@@ -144,7 +144,10 @@ defmodule Neoboard.Widgets.RedmineActivity.Parser do
   end
 
   defp extract_project_name(entry) do
-    entry |> Xml.first('./title') |> Xml.text |> match(~r/^([&\w\-_ ]+) - /)
+    entry
+    |> Xml.first('./title')
+    |> Xml.text
+    |> match(~r/^(.+) - /U)
   end
 
   defp extract_updated(entry) do
@@ -171,7 +174,7 @@ defmodule Neoboard.Widgets.RedmineActivity.Xml do
 
   def xpath(nil, _), do: []
   def xpath(node, path) do
-    :xmerl_xpath.string(to_char_list(path), node)
+    :xmerl_xpath.string(to_charlist(path), node)
   end
   def first(node, path), do: node |> xpath(path) |> List.first
 

--- a/test/neoboard/widgets/redmine_activity_fixture.xml
+++ b/test/neoboard/widgets/redmine_activity_fixture.xml
@@ -52,7 +52,7 @@ Redmine  </generator>
     </content>
   </entry>
   <entry>
-    <title>project3 &amp; more - Revision 706ee6fd (project3): Merge branch 'feature-xyz'</title>
+    <title>project3 &amp; [møre] - Revision 706ee6fd (project3): Merge branch 'feature-xyz'</title>
     <link rel="alternate" href="https://redmine.company.com/projects/project3/repository/revisions/706ee6fd874515cb6de082d1a9a22dda1709a249"/>
     <id>https://redmine.company.com/projects/project3/repository/revisions/706ee6fd874515cb6de082d1a9a22dda1709a249</id>
     <updated>2015-05-18T15:02:59Z</updated>

--- a/test/neoboard/widgets/redmine_activity_test.exs
+++ b/test/neoboard/widgets/redmine_activity_test.exs
@@ -19,7 +19,7 @@ defmodule Neoboard.Widgets.RedmineActivityTest do
     assert Enum.empty?(rest)
 
     [second | one_project] = two_projects
-    assert second.name       == "project3 & more"
+    assert second.name       == "project3 & [møre]"
     assert second.activity   == 1
     assert second.updated_at == ~N[2015-05-18 15:02:59] |> Timex.to_datetime
     [user | rest] = second.users


### PR DESCRIPTION
Project names with special chars canceled the parsing of Redmine's activity feed.

/cc @wakkowarner 